### PR TITLE
Delete old magic comment

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class App < Sinatra::Base
   get '/servo' do
     pan = params['pan']


### PR DESCRIPTION
`# encoding: utf-8` は昔のマジックコメント。
Qiitaからsinatraのサンプルをコピーした際の消し忘れでした 🙇 
